### PR TITLE
Fix so that missing argument without an underscore is printed correctly.

### DIFF
--- a/lib/chef/knife/bmcs_helper.rb
+++ b/lib/chef/knife/bmcs_helper.rb
@@ -48,7 +48,7 @@ class Chef
           params[param].nil?
         end
 
-        error_and_exit("Missing the following required parameters: #{missing_params.join(', ').tr!('_', '-')}") unless missing_params.empty?
+        error_and_exit("Missing the following required parameters: #{missing_params.join(', ').tr('_', '-')}") unless missing_params.empty?
       end
 
       def warn_if_page_is_truncated(response)


### PR DESCRIPTION
Signed-off-by: john_l_hopkins <john.l.hopkins@oracle.com>

In bmcs_helper.rb validate_params, if the user is missing an argument that does not contain an underscore (eg. 'shape') then a blank is printed to the screen instead of the argument name.

The issue is with how `tr!` works in that case:

.gem :003 > "av_domain".tr!('_','-')
 => "av-domain"     ## works fine because string includes an underscore
[vagrant@localhost knife-bmcs]$ irb
.gem :001 > "shape".tr!('_','-')
 => nil
.gem :002 > "shape".tr('_','-')
 => "shape"

The fix (as shown above) is to call `tr` instead of `tr!`