### PR TITLE
Parameterize integ tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 chef-repo/
 dist/
 Gemfile.lock
+test_output/list_commands
+test_output/server_create

--- a/spec/integration/list_commands_integ_spec.rb
+++ b/spec/integration/list_commands_integ_spec.rb
@@ -22,7 +22,8 @@ end
 describe 'list commands' do
   let(:params_only_bmcs_config) do
     {
-      '--bmcs-config-file' => config_file_path
+      '--bmcs-config-file' => config_file_path,
+      '--bmcs-profile' => profile
     }
   end
 
@@ -35,6 +36,7 @@ describe 'list commands' do
   let(:params_with_compartment) do
     {
       '--bmcs-config-file' => config_file_path,
+      '--bmcs-profile' => profile,
       '--compartment-id' => compartment_id
     }
   end

--- a/spec/integration/server_create_integ_spec.rb
+++ b/spec/integration/server_create_integ_spec.rb
@@ -36,9 +36,10 @@ describe 'server create command' do
       '--availability-domain' => availability_domain,
       '--compartment-id' => compartment_id,
       '--subnet-id' => subnet_id,
-      '--shape' => 'VM.Standard1.1',
+      '--shape' => shape,
       '--image-id' => 'Must be set for each run.',
       '--bmcs-config-file' => config_file_path,
+      '--bmcs-profile' => profile,
       '--ssh-authorized-keys-file' => public_ssh_key_file,
       '--identity-file' => private_key_file,
       '--ssh-user' => 'opc',
@@ -64,53 +65,32 @@ describe 'server create command' do
       if match && match.length > 1
         instance_id = match[1]
         puts "Clean Up: Terminating instance #{instance_id}."
-        client = OracleBMC::Core::ComputeClient.new(config: OracleBMC::ConfigFileLoader.load_config(config_file_location: config_file_path))
+        client = OracleBMC::Core::ComputeClient.new(config: OracleBMC::ConfigFileLoader.load_config(config_file_location: config_file_path, profile_name: profile))
         client.terminate_instance(instance_id)
       end
     end
   end
 
-  it 'can create Oracle-Linux-7.3-2017.04.18-0 instance with min params' do
+  it 'can create an Oracle Linux instance with min params' do
     params = min_params
-    params['--image-id'] = 'ocid1.image.oc1.phx.aaaaaaaaqutj4qjxihpl4mboabsa27mrpusygv6gurp47kat5z7vljmq3puq'
-    shell = run_server_create(params, 'oracle_linux_7_min_params')
+    params['--image-id'] = oracle_linux_image_id
+    shell = run_server_create(params, 'test_oracle_linux_min_params')
     validate_output(shell, params)
   end
 
-  it 'can create Oracle-Linux-7.3-2017.04.18-0 instance with all params' do
+  it 'can create an Oracle Linux instance with all params' do
     params = min_params.merge(extra_params)
-    params['--image-id'] = 'ocid1.image.oc1.phx.aaaaaaaaqutj4qjxihpl4mboabsa27mrpusygv6gurp47kat5z7vljmq3puq'
-    shell = run_server_create(params, 'oracle_linux_7_all_params')
+    params['--image-id'] = oracle_linux_image_id
+    shell = run_server_create(params, 'test_oracle_linux_all_params')
     validate_output(shell, params)
     expect(shell.stdout).to include(params['--display-name'])
   end
 
-  it 'can create Oracle-Linux-6.8-2017.03.02-0 instance' do
+  it 'can create an Ubuntu instance' do
     params = min_params
-    params['--image-id'] = 'ocid1.image.oc1.phx.aaaaaaaawrkdsfnl327clq3cszhhjujxl5rh6htn2arcz5icdih36ohyip2q'
-    shell = run_server_create(params, 'oracle_linux_6')
-    validate_output(shell, params)
-  end
-
-  it 'can create a CentOS-7-2017.04.18-0 instance' do
-    params = min_params
-    params['--image-id'] = 'ocid1.image.oc1.phx.aaaaaaaaamx6ta37uxltor6n5lxfgd5lkb3lwmoqurlpn2x4dz5ockekiuea'
-    shell = run_server_create(params, 'centos_7')
-    validate_output(shell, params)
-  end
-
-  it 'can create a CentOS-6.8-2017.02.03-0 instance' do
-    params = min_params
-    params['--image-id'] = 'ocid1.image.oc1.phx.aaaaaaaa52piclnuizazimz7kekehatfcxkozzf3deqelfmjc5qeiqkrpryq'
-    shell = run_server_create(params, 'centos_6')
-    validate_output(shell, params)
-  end
-
-  it 'can create a Canonical-Ubuntu-16.04-2017.05.16-0 instance' do
-    params = min_params
-    params['--image-id'] = 'ocid1.image.oc1.phx.aaaaaaaae3a3oedsmmwsqu4dsrzntekefgq7vosngn4r6u6n5mis7dwpxxpa'
+    params['--image-id'] = ubuntu_image_id
     params['--ssh-user'] = 'ubuntu'
-    shell = run_server_create(params, 'ubuntu_16')
+    shell = run_server_create(params, 'test_ubuntu')
     validate_output(shell, params)
   end
 end

--- a/spec/resources/knife.rb
+++ b/spec/resources/knife.rb
@@ -7,4 +7,5 @@ log_location             STDOUT
 chef_server_url          'https://111.111.111.111/organizations/myinc'
 
 knife[:bmcs_config_file] = ENV['KNIFE_BMCS_CONFIG_FILE']
+knife[:bmcs_profile] = ENV['KNIFE_BMCS_PROFILE']
 knife[:compartment_id] = ENV['KNIFE_BMCS_COMPARTMENT']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,26 +22,52 @@ DUMMY_PRIVATE_KEY_FILE = 'spec/resources/dummy_ssh_key'.freeze
 DUMMY_CONFIG_FILE = 'spec/resources/config_for_unit_tests'.freeze
 
 def compartment_id
+  # Example value: ocid1.compartment.oc1..aaaaaaaa7x9zzwkqlcyupl6msnblrhffavz6bu6phk7q265kfsil3ileabcq
   ENV['KNIFE_BMCS_COMPARTMENT']
 end
 
 def availability_domain
+  # Example value: IxGV:US-ASHBURN-AD-2
   ENV['KNIFE_BMCS_AD']
 end
 
 def config_file_path
+  # Example value: ~/.oraclebmc/config
   ENV['KNIFE_BMCS_CONFIG_FILE']
 end
 
+def profile
+  # Example value: DEFAULT
+  ENV['KNIFE_BMCS_PROFILE']
+end
+
 def subnet_id
+  # Example value: ocid1.subnet.oc1.iad.aaaaaaaacuqa4rii7bwqyanrarfmqgsz6qptljsvqijcpcspfaty4lab8nza
   ENV['KNIFE_BMCS_SUBNET']
 end
 
+def shape
+  # Example value: VM.Standard1.1
+  ENV['KNIFE_BMCS_SHAPE']
+end
+
+def oracle_linux_image_id
+  # Example value: ocid1.image.oc1.iad.aaaaaaaah2d5y4jlyi6q5mus4ihabunzdzuiwmuc3pequv27jfkc5eb4ylcq
+  ENV['KNIFE_BMCS_ORACLE_LINUX_ID']
+end
+
+def ubuntu_image_id
+  # Example value: ocid1.image.oc1.iad.aaaaaaaa25xqs7rqfkf7ukgwnpzvyhbg3qd4rplu7yl5tpnmdkzzeudr3s2a
+  ENV['KNIFE_BMCS_UBUNTU_ID']
+end
+
 def public_ssh_key_file
+  # Example value: ~/.keys/instance_keys.pub
   ENV['KNIFE_BMCS_PUBLIC_SSH_KEY_FILE']
 end
 
 def private_key_file
+  # Example value: ~/.keys/instance_keys
   ENV['KNIFE_BMCS_PRIVATE_KEY_FILE']
 end
 
@@ -66,6 +92,7 @@ def write_command_to_file(subcommand, file, directory)
   output = output + "\n\n" + shell.stdout unless shell.stdout.empty?
   output = output + "\n\n+++ STDERR +++\n\n" + shell.stderr unless shell.stderr.empty?
 
+  Dir.mkdir(directory) unless Dir.exist?(directory)
   File.open(File.join(directory, file + '.txt'), 'w') { |f| f.write(output) }
   shell
 end


### PR DESCRIPTION
Parameterizes a few additional integ test values, which will allow running
the tests in IAD and using a non-default profile.
Also creates necessary test_output directories if they don't already exist.