### PR TITLE
Make --ssh-authorized-keys-file a required argument to server create.

### DIFF
--- a/lib/chef/knife/bmcs_server_create.rb
+++ b/lib/chef/knife/bmcs_server_create.rb
@@ -65,7 +65,7 @@ class Chef
              description: 'A file containing one or more public SSH keys to be included in the ~/.ssh/authorized_keys file for the default user on the instance. '\
                           'Use a newline character to separate multiple keys. The SSH keys must be in the format necessary for the authorized_keys file. This parameter '\
                           "is a convenience wrapper around the 'ssh_authorized_keys' field of the --metadata parameter. Populating both values in the same call will result "\
-                          'in an error. For more info see documentation: https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/requests/LaunchInstanceDetails.'
+                          'in an error. For more info see documentation: https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/requests/LaunchInstanceDetails. (required)'
 
       option :assign_public_ip,
              long: '--assign-public-ip BOOLEAN',
@@ -128,7 +128,7 @@ class Chef
 
       def run
         $stdout.sync = true
-        validate_required_params(%i[availability_domain image_id shape subnet_id identity_file], config)
+        validate_required_params(%i[availability_domain image_id shape subnet_id identity_file ssh_authorized_keys_file], config)
         validate_wait_options
 
         metadata = merge_metadata

--- a/spec/unit/server_create_spec.rb
+++ b/spec/unit/server_create_spec.rb
@@ -40,7 +40,7 @@ describe Chef::Knife::BmcsServerCreate do
     end
 
     it 'should list missing required params' do
-      expect(knife_bmcs_server_create.ui).to receive(:error).with('Missing the following required parameters: availability-domain, image-id, shape, subnet-id, identity-file')
+      expect(knife_bmcs_server_create.ui).to receive(:error).with('Missing the following required parameters: availability-domain, image-id, shape, subnet-id, identity-file, ssh-authorized-keys-file')
       expect { knife_bmcs_server_create.run }.to raise_error(SystemExit)
     end
 

--- a/test_output/help/server_create.txt
+++ b/test_output/help/server_create.txt
@@ -35,7 +35,7 @@ knife bmcs server create (options)
     -r, --run-list RUN_LIST          A comma-separated list of roles or recipes.
         --shape SHAPE                The shape of an instance. The shape determines the number of CPUs, amount of memory, and other resources allocated to the instance. (required)
         --ssh-authorized-keys-file FILE
-                                     A file containing one or more public SSH keys to be included in the ~/.ssh/authorized_keys file for the default user on the instance. Use a newline character to separate multiple keys. The SSH keys must be in the format necessary for the authorized_keys file. This parameter is a convenience wrapper around the 'ssh_authorized_keys' field of the --metadata parameter. Populating both values in the same call will result in an error. For more info see documentation: https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/requests/LaunchInstanceDetails.
+                                     A file containing one or more public SSH keys to be included in the ~/.ssh/authorized_keys file for the default user on the instance. Use a newline character to separate multiple keys. The SSH keys must be in the format necessary for the authorized_keys file. This parameter is a convenience wrapper around the 'ssh_authorized_keys' field of the --metadata parameter. Populating both values in the same call will result in an error. For more info see documentation: https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/requests/LaunchInstanceDetails. (required)
     -P, --ssh-password PASSWORD      The SSH password
     -x, --ssh-user USERNAME          The SSH username. Defaults to opc.
         --subnet-id SUBNET           The OCID of the subnet. (required)


### PR DESCRIPTION
Make --ssh-authorized-keys-file a required argument to server create.

Signed-off-by: john_l_hopkins <john.l.hopkins@oracle.com>