### PR TITLE
Jlh auto fetch all pages

### DIFF
--- a/lib/chef/knife/bmcs_ad_list.rb
+++ b/lib/chef/knife/bmcs_ad_list.rb
@@ -18,11 +18,21 @@ class Chef
       end
 
       def run
-        response = identity_client.list_availability_domains(compartment_id)
+        options = {}
+        columns = []
 
-        display_list(response, []) do |item|
-          [item.name]
+        list_for_display, last_response = get_display_results(options) do |_client_options, first_row|
+          response = identity_client.list_availability_domains(compartment_id)
+
+          items = response_to_list(response,
+                                   columns, include_headings: first_row) do |item|
+            [item.name]
+          end
+          [response, items]
         end
+
+        display_list_from_array(list_for_display, columns.length)
+        warn_if_page_is_truncated(last_response)
       end
     end
   end

--- a/lib/chef/knife/bmcs_ad_list.rb
+++ b/lib/chef/knife/bmcs_ad_list.rb
@@ -21,10 +21,10 @@ class Chef
         options = {}
         columns = []
 
-        list_for_display, last_response = get_display_results(options) do |_client_options, first_row|
-          response = identity_client.list_availability_domains(compartment_id)
+        list_for_display, last_response = get_display_results(options) do |client_options|
+          response = identity_client.list_availability_domains(compartment_id, client_options)
 
-          items = response_to_list(response, columns, include_headings: first_row) do |item|
+          items = response_to_list(response) do |item|
             [item.name]
           end
           [response, items]

--- a/lib/chef/knife/bmcs_ad_list.rb
+++ b/lib/chef/knife/bmcs_ad_list.rb
@@ -24,8 +24,7 @@ class Chef
         list_for_display, last_response = get_display_results(options) do |_client_options, first_row|
           response = identity_client.list_availability_domains(compartment_id)
 
-          items = response_to_list(response,
-                                   columns, include_headings: first_row) do |item|
+          items = response_to_list(response, columns, include_headings: first_row) do |item|
             [item.name]
           end
           [response, items]

--- a/lib/chef/knife/bmcs_compartment_list.rb
+++ b/lib/chef/knife/bmcs_compartment_list.rb
@@ -25,19 +25,20 @@ class Chef
         options = {}
         options[:limit] = config[:limit] if config[:limit]
 
-        response = identity_client.list_compartments(bmcs_config.tenancy, options)
-        # Check whether there is a next page to decide whether to show an 'output is truncated' warning.
-        # TODO: expected to be addressed server-side in a future release at which point this special
-        # handling can be removed.
-        show_truncated_warning = false
-        if response && response.headers.include?('opc-next-page')
-          response_page2 = identity_client.list_compartments(bmcs_config.tenancy, options.merge(page: response.headers['opc-next-page']))
-          show_truncated_warning = response_page2 && response_page2.data && !response_page2.data.empty?
+        columns = ['Display Name', 'ID']
+
+        list_for_display, last_response = get_display_results(options) do |client_options, first_row|
+          response = identity_client.list_compartments(bmcs_config.tenancy, client_options)
+
+          items = response_to_list(response,
+                                   columns, include_headings: first_row) do |item|
+            [item.name, item.id]
+          end
+          [response, items]
         end
 
-        display_list(response, ['Display Name', 'ID'], warn_on_truncated: show_truncated_warning) do |item|
-          [item.name, item.id]
-        end
+        display_list_from_array(list_for_display, columns.length)
+        warn_if_page_is_truncated(last_response)
       end
     end
   end

--- a/lib/chef/knife/bmcs_compartment_list.rb
+++ b/lib/chef/knife/bmcs_compartment_list.rb
@@ -30,8 +30,7 @@ class Chef
         list_for_display, last_response = get_display_results(options) do |client_options, first_row|
           response = identity_client.list_compartments(bmcs_config.tenancy, client_options)
 
-          items = response_to_list(response,
-                                   columns, include_headings: first_row) do |item|
+          items = response_to_list(response, columns, include_headings: first_row) do |item|
             [item.name, item.id]
           end
           [response, items]

--- a/lib/chef/knife/bmcs_compartment_list.rb
+++ b/lib/chef/knife/bmcs_compartment_list.rb
@@ -27,14 +27,16 @@ class Chef
 
         columns = ['Display Name', 'ID']
 
-        list_for_display, last_response = get_display_results(options) do |client_options, first_row|
+        list_for_display = config[:format] == 'summary' ? bold(columns) : []
+        list_data, last_response = get_display_results(options) do |client_options|
           response = identity_client.list_compartments(bmcs_config.tenancy, client_options)
 
-          items = response_to_list(response, columns, include_headings: first_row) do |item|
+          items = response_to_list(response) do |item|
             [item.name, item.id]
           end
           [response, items]
         end
+        list_for_display += list_data
 
         display_list_from_array(list_for_display, columns.length)
         warn_if_page_is_truncated(last_response)

--- a/lib/chef/knife/bmcs_helper.rb
+++ b/lib/chef/knife/bmcs_helper.rb
@@ -57,43 +57,99 @@ class Chef
         ui.warn('This list has been truncated. To view more items, increase the limit.') if response.headers.include? 'opc-next-page'
       end
 
-      # TODO: Method should be refactored to reduce complexity.
-      # rubocop:disable Metrics/PerceivedComplexity
-      def display_list(response, columns, warn_on_truncated: true)
-        list = if response.data.nil?
-                 []
-               else
-                 response.data.is_a?(Array) ? response.data : [response.data]
-               end
+      def next_page_token(response)
+        return response.headers['opc-next-page'] if response.headers.include? 'opc-next-page'
+        nil
+      end
+
+      def get_display_results(options)
+        max_results = config[:limit] ? Integer(config[:limit]) : nil
+
+        num_fetched_results = 0
+        list_for_display = []
+        first_row = true
+        response = nil
+        loop do
+          response, new_items = yield(options, first_row)
+
+          list_for_display += new_items
+          num_fetched_results += response.data.length if response.data
+          break if next_page_token(response).nil?
+          break if max_results && num_fetched_results >= max_results
+          first_row = false
+          options[:page] = next_page_token(response)
+          options[:limit] = (max_results - num_fetched_results).to_s if max_results
+        end
+        [list_for_display, response]
+      end
+
+      # Return data in summary mode format, optionally including column headings.
+      def _summary_list(list, columns, include_headings: true)
         list_for_display = []
 
-        if config[:format] == 'summary'
-          width = 1
-
-          unless columns.empty?
+        unless columns.empty?
+          if include_headings
             columns.each do |column|
               list_for_display += [ui.color(column, :bold)]
             end
 
             list_for_display = list_for_display.flatten.compact
-            width = columns.length
           end
+        end
 
-          if list
-            list.each do |item|
-              display_item = yield(item, list_for_display)
-              list_for_display += display_item if display_item
-            end
-          end
-
-          puts ui.list(list_for_display, :uneven_columns_across, width)
-        else
+        if list
           list.each do |item|
-            list_for_display += [item.to_hash]
+            display_item = yield(item, list_for_display)
+            list_for_display += display_item if display_item
           end
+        end
 
+        list_for_display
+      end
+
+      # Return data in non-summary mode format.
+      def _non_summary_list(list)
+        list_for_display = []
+        list.each do |item|
+          list_for_display += [item.to_hash]
+        end
+
+        list_for_display
+      end
+
+      # Return a one dimensional array of data based on API response.
+      # Result is compatible with display_list_from_array.
+      def response_to_list(response, columns, include_headings: true, &block)
+        list = if response.data.nil?
+                 []
+               else
+                 response.data.is_a?(Array) ? response.data : [response.data]
+               end
+
+        return _summary_list(list, columns, include_headings: include_headings, &block) if config[:format] == 'summary'
+        _non_summary_list(list)
+      end
+
+      # Display a list using a one dimensional array as input
+      #
+      # Example output in summary mode:
+      # display_list_from_array(['a','b', 'c', 'd'], 2)
+      # a  b
+      # c  d
+      def display_list_from_array(list_for_display, num_columns)
+        if config[:format] == 'summary'
+          num_columns = 1 if num_columns < 1
+          puts ui.list(list_for_display, :uneven_columns_across, num_columns)
+        else
           ui.output(list_for_display)
         end
+      end
+
+      # Display a list using an API response object as input.
+      def display_list(response, columns, warn_on_truncated: true, include_headings: true, &block)
+        list_for_display = response_to_list(response, columns, include_headings: include_headings, &block)
+        width = columns.empty? ? 1 : columns.length
+        display_list_from_array(list_for_display, width)
 
         warn_if_page_is_truncated(response) if warn_on_truncated
       end

--- a/lib/chef/knife/bmcs_image_list.rb
+++ b/lib/chef/knife/bmcs_image_list.rb
@@ -30,8 +30,7 @@ class Chef
         list_for_display, last_response = get_display_results(options) do |client_options, first_row|
           response = compute_client.list_images(compartment_id, client_options)
 
-          items = response_to_list(response,
-                                   columns, include_headings: first_row) do |image|
+          items = response_to_list(response, columns, include_headings: first_row) do |image|
             [image.display_name, image.id, image.operating_system, image.operating_system_version]
           end
           [response, items]

--- a/lib/chef/knife/bmcs_image_list.rb
+++ b/lib/chef/knife/bmcs_image_list.rb
@@ -25,11 +25,20 @@ class Chef
         options = {}
         options[:limit] = config[:limit] if config[:limit]
 
-        response = compute_client.list_images(compartment_id, options)
+        columns = ['Display Name', 'ID', 'OS', 'OS Version']
 
-        display_list(response, ['Display Name', 'ID', 'OS', 'OS Version']) do |image|
-          [image.display_name, image.id, image.operating_system, image.operating_system_version]
+        list_for_display, last_response = get_display_results(options) do |client_options, first_row|
+          response = compute_client.list_images(compartment_id, client_options)
+
+          items = response_to_list(response,
+                                   columns, include_headings: first_row) do |image|
+            [image.display_name, image.id, image.operating_system, image.operating_system_version]
+          end
+          [response, items]
         end
+
+        display_list_from_array(list_for_display, columns.length)
+        warn_if_page_is_truncated(last_response)
       end
     end
   end

--- a/lib/chef/knife/bmcs_image_list.rb
+++ b/lib/chef/knife/bmcs_image_list.rb
@@ -27,14 +27,16 @@ class Chef
 
         columns = ['Display Name', 'ID', 'OS', 'OS Version']
 
-        list_for_display, last_response = get_display_results(options) do |client_options, first_row|
+        list_for_display = config[:format] == 'summary' ? bold(columns) : []
+        list_data, last_response = get_display_results(options) do |client_options|
           response = compute_client.list_images(compartment_id, client_options)
 
-          items = response_to_list(response, columns, include_headings: first_row) do |image|
+          items = response_to_list(response) do |image|
             [image.display_name, image.id, image.operating_system, image.operating_system_version]
           end
           [response, items]
         end
+        list_for_display += list_data
 
         display_list_from_array(list_for_display, columns.length)
         warn_if_page_is_truncated(last_response)

--- a/lib/chef/knife/bmcs_server_list.rb
+++ b/lib/chef/knife/bmcs_server_list.rb
@@ -28,16 +28,18 @@ class Chef
 
         columns = ['Display Name', 'State', 'ID']
 
-        list_for_display, last_response = get_display_results(options) do |client_options, first_row|
+        list_for_display = config[:format] == 'summary' ? bold(columns) : []
+        list_data, last_response = get_display_results(options) do |client_options|
           response = compute_client.list_instances(compartment_id, client_options)
 
-          items = response_to_list(response, columns, include_headings: first_row) do |item|
+          items = response_to_list(response) do |item|
             [item.display_name,
              item.lifecycle_state,
              item.id]
           end
           [response, items]
         end
+        list_for_display += list_data
 
         display_list_from_array(list_for_display, columns.length)
         warn_if_page_is_truncated(last_response)

--- a/lib/chef/knife/bmcs_server_list.rb
+++ b/lib/chef/knife/bmcs_server_list.rb
@@ -26,14 +26,22 @@ class Chef
         options = {}
         options[:limit] = config[:limit] if config[:limit]
 
-        response = compute_client.list_instances(compartment_id, options)
+        columns = ['Display Name', 'State', 'ID']
 
-        display_list(response,
-                     ['Display Name', 'State', 'ID']) do |item|
-          [item.display_name,
-           item.lifecycle_state,
-           item.id]
+        list_for_display, last_response = get_display_results(options) do |client_options, first_row|
+          response = compute_client.list_instances(compartment_id, client_options)
+
+          items = response_to_list(response,
+                                   columns, include_headings: first_row) do |item|
+            [item.display_name,
+             item.lifecycle_state,
+             item.id]
+          end
+          [response, items]
         end
+
+        display_list_from_array(list_for_display, columns.length)
+        warn_if_page_is_truncated(last_response)
       end
     end
   end

--- a/lib/chef/knife/bmcs_server_list.rb
+++ b/lib/chef/knife/bmcs_server_list.rb
@@ -31,8 +31,7 @@ class Chef
         list_for_display, last_response = get_display_results(options) do |client_options, first_row|
           response = compute_client.list_instances(compartment_id, client_options)
 
-          items = response_to_list(response,
-                                   columns, include_headings: first_row) do |item|
+          items = response_to_list(response, columns, include_headings: first_row) do |item|
             [item.display_name,
              item.lifecycle_state,
              item.id]

--- a/lib/chef/knife/bmcs_shape_list.rb
+++ b/lib/chef/knife/bmcs_shape_list.rb
@@ -40,8 +40,7 @@ class Chef
         list_for_display, last_response = get_display_results(options) do |client_options, first_row|
           response = compute_client.list_shapes(compartment_id, client_options)
 
-          items = response_to_list(response,
-                                   columns, include_headings: first_row) do |item|
+          items = response_to_list(response, columns, include_headings: first_row) do |item|
             [item.shape]
           end
           [response, items]

--- a/lib/chef/knife/bmcs_shape_list.rb
+++ b/lib/chef/knife/bmcs_shape_list.rb
@@ -37,10 +37,10 @@ class Chef
 
         columns = []
 
-        list_for_display, last_response = get_display_results(options) do |client_options, first_row|
+        list_for_display, last_response = get_display_results(options) do |client_options|
           response = compute_client.list_shapes(compartment_id, client_options)
 
-          items = response_to_list(response, columns, include_headings: first_row) do |item|
+          items = response_to_list(response) do |item|
             [item.shape]
           end
           [response, items]

--- a/lib/chef/knife/bmcs_shape_list.rb
+++ b/lib/chef/knife/bmcs_shape_list.rb
@@ -35,11 +35,21 @@ class Chef
         options[:image_id] = config[:image_id] if config[:image_id]
         options[:limit] = config[:limit] if config[:limit]
 
-        response = compute_client.list_shapes(compartment_id, options)
+        columns = []
 
-        display_list(response, []) do |item, list|
-          [item.shape] unless list.include? item.shape
+        list_for_display, last_response = get_display_results(options) do |client_options, first_row|
+          response = compute_client.list_shapes(compartment_id, client_options)
+
+          items = response_to_list(response,
+                                   columns, include_headings: first_row) do |item|
+            [item.shape]
+          end
+          [response, items]
         end
+
+        list_for_display.uniq!
+        display_list_from_array(list_for_display, columns.length)
+        warn_if_page_is_truncated(last_response)
       end
     end
   end

--- a/lib/chef/knife/bmcs_subnet_list.rb
+++ b/lib/chef/knife/bmcs_subnet_list.rb
@@ -32,14 +32,16 @@ class Chef
 
         columns = ['Display Name', 'ID', 'CIDR Block', 'Availability Domain', 'State']
 
-        list_for_display, last_response = get_display_results(options) do |client_options, first_row|
+        list_for_display = config[:format] == 'summary' ? bold(columns) : []
+        list_data, last_response = get_display_results(options) do |client_options|
           response = network_client.list_subnets(compartment_id, config[:vcn_id], client_options)
 
-          items = response_to_list(response, columns, include_headings: first_row) do |item|
+          items = response_to_list(response) do |item|
             [item.display_name, item.id, item.cidr_block, item.availability_domain, item.lifecycle_state]
           end
           [response, items]
         end
+        list_for_display += list_data
 
         display_list_from_array(list_for_display, columns.length)
         warn_if_page_is_truncated(last_response)

--- a/lib/chef/knife/bmcs_subnet_list.rb
+++ b/lib/chef/knife/bmcs_subnet_list.rb
@@ -35,8 +35,7 @@ class Chef
         list_for_display, last_response = get_display_results(options) do |client_options, first_row|
           response = network_client.list_subnets(compartment_id, config[:vcn_id], client_options)
 
-          items = response_to_list(response,
-                                   columns, include_headings: first_row) do |item|
+          items = response_to_list(response, columns, include_headings: first_row) do |item|
             [item.display_name, item.id, item.cidr_block, item.availability_domain, item.lifecycle_state]
           end
           [response, items]

--- a/lib/chef/knife/bmcs_vcn_list.rb
+++ b/lib/chef/knife/bmcs_vcn_list.rb
@@ -25,11 +25,19 @@ class Chef
         options = {}
         options[:limit] = config[:limit] if config[:limit]
 
-        response = network_client.list_vcns(compartment_id, options)
+        columns = ['Display Name', 'ID', 'CIDR Block', 'State']
 
-        display_list(response, ['Display Name', 'ID', 'CIDR Block', 'State']) do |item|
-          [item.display_name, item.id, item.cidr_block, item.lifecycle_state]
+        list_for_display, last_response = get_display_results(options) do |client_options, first_row|
+          response = network_client.list_vcns(compartment_id, client_options)
+
+          items = response_to_list(response, columns, include_headings: first_row) do |item|
+            [item.display_name, item.id, item.cidr_block, item.lifecycle_state]
+          end
+          [response, items]
         end
+
+        display_list_from_array(list_for_display, columns.length)
+        warn_if_page_is_truncated(last_response)
       end
     end
   end

--- a/lib/chef/knife/bmcs_vcn_list.rb
+++ b/lib/chef/knife/bmcs_vcn_list.rb
@@ -27,14 +27,16 @@ class Chef
 
         columns = ['Display Name', 'ID', 'CIDR Block', 'State']
 
-        list_for_display, last_response = get_display_results(options) do |client_options, first_row|
+        list_for_display = config[:format] == 'summary' ? bold(columns) : []
+        list_data, last_response = get_display_results(options) do |client_options|
           response = network_client.list_vcns(compartment_id, client_options)
 
-          items = response_to_list(response, columns, include_headings: first_row) do |item|
+          items = response_to_list(response) do |item|
             [item.display_name, item.id, item.cidr_block, item.lifecycle_state]
           end
           [response, items]
         end
+        list_for_display += list_data
 
         display_list_from_array(list_for_display, columns.length)
         warn_if_page_is_truncated(last_response)

--- a/spec/unit/ad_list_spec.rb
+++ b/spec/unit/ad_list_spec.rb
@@ -4,7 +4,6 @@ require './spec/spec_helper'
 require 'json'
 require 'chef/knife/bmcs_ad_list'
 
-# rubocop:disable Metrics/AbcSize
 def run_tests(output_format)
   receive_type = output_format == 'summary' ? :list : :output
 
@@ -37,18 +36,6 @@ def run_tests(output_format)
     allow(knife_bmcs_ad_list.identity_client).to receive(:list_availability_domains).and_return(nil_response)
     expect(knife_bmcs_ad_list.ui).to receive(receive_type)
     expect(knife_bmcs_ad_list.ui).not_to receive(:warn)
-
-    knife_bmcs_ad_list.run
-  end
-
-  it "warns #{output_format} when truncated" do
-    knife_bmcs_ad_list.config = config
-    knife_bmcs_ad_list.config[:format] = output_format
-    response.headers['opc-next-page'] = 'page2'
-
-    allow(knife_bmcs_ad_list.identity_client).to receive(:list_availability_domains).and_return(response)
-    expect(knife_bmcs_ad_list.ui).to receive(receive_type)
-    expect(knife_bmcs_ad_list.ui).to receive(:warn).with('This list has been truncated. To view more items, increase the limit.')
 
     knife_bmcs_ad_list.run
   end

--- a/spec/unit/bmcs_common_spec.rb
+++ b/spec/unit/bmcs_common_spec.rb
@@ -42,6 +42,7 @@ describe 'bmcs common utilities' do
 
       allow(knife_bmcs_subnet_list.network_client).to receive(:list_subnets).and_return(empty_response)
       expect(knife_bmcs_subnet_list.ui).not_to receive(:warn)
+      expect(knife_bmcs_subnet_list.ui).to receive(:output)
       expect(knife_bmcs_subnet_list.bmcs_config.region).to eq('overridden-region')
       expect(knife_bmcs_subnet_list.compute_client.region).to eq('overridden-region')
 

--- a/spec/unit/compartment_list_spec.rb
+++ b/spec/unit/compartment_list_spec.rb
@@ -57,10 +57,11 @@ def run_tests(output_format)
   it "shows warning #{output_format} when truncated" do
     knife_bmcs_compartment_list.config = config
     knife_bmcs_compartment_list.config[:format] = output_format
+    knife_bmcs_compartment_list.config[:limit] = 1
     response = multi_response
     response.headers['opc-next-page'] = 'page2'
 
-    allow(knife_bmcs_compartment_list.identity_client).to receive(:list_compartments).and_return(response)
+    allow(knife_bmcs_compartment_list.identity_client).to receive(:list_compartments).and_return(response, empty_response)
     expect(knife_bmcs_compartment_list.ui).to receive(receive_type)
     expect(knife_bmcs_compartment_list.ui).to receive(:warn).with('This list has been truncated. To view more items, increase the limit.')
 
@@ -110,12 +111,12 @@ describe Chef::Knife::BmcsCompartmentList do
 
     let(:empty_response) do
       double(data: [],
-             headers: { 'opc-next-page' => 'aaaaaaaaaaaaaaaa' })
+             headers: {})
     end
 
     let(:nil_response) do
       double(data: nil,
-             headers: { 'opc-next-page' => 'aaaaaaaaaaaaaaaa' })
+             headers: {})
     end
 
     run_tests('summary')

--- a/spec/unit/image_list_spec.rb
+++ b/spec/unit/image_list_spec.rb
@@ -44,9 +44,10 @@ def run_tests(output_format)
   it "warns #{output_format} when truncated" do
     knife_bmcs_image_list.config = config
     knife_bmcs_image_list.config[:format] = output_format
+    knife_bmcs_image_list.config[:limit] = 1
     response.headers['opc-next-page'] = 'page2'
 
-    allow(knife_bmcs_image_list.compute_client).to receive(:list_images).and_return(response)
+    allow(knife_bmcs_image_list.compute_client).to receive(:list_images).and_return(response, empty_response)
     expect(knife_bmcs_image_list.ui).to receive(receive_type)
     expect(knife_bmcs_image_list.ui).to receive(:warn).with('This list has been truncated. To view more items, increase the limit.')
 

--- a/spec/unit/server_list_spec.rb
+++ b/spec/unit/server_list_spec.rb
@@ -44,9 +44,10 @@ def run_tests(output_format)
   it "warns #{output_format} when truncated" do
     knife_bmcs_server_list.config = config
     knife_bmcs_server_list.config[:format] = output_format
+    knife_bmcs_server_list.config[:limit] = 1
     response.headers['opc-next-page'] = 'page2'
 
-    allow(knife_bmcs_server_list.compute_client).to receive(:list_instances).and_return(response)
+    allow(knife_bmcs_server_list.compute_client).to receive(:list_instances).and_return(response, empty_response)
     expect(knife_bmcs_server_list.ui).to receive(receive_type)
     expect(knife_bmcs_server_list.ui).to receive(:warn).with('This list has been truncated. To view more items, increase the limit.')
 

--- a/spec/unit/shape_list_spec.rb
+++ b/spec/unit/shape_list_spec.rb
@@ -44,9 +44,10 @@ def run_tests(output_format)
   it "warns #{output_format} when truncated" do
     knife_bmcs_shape_list.config = config
     knife_bmcs_shape_list.config[:format] = output_format
+    knife_bmcs_shape_list.config[:limit] = 1
     response.headers['opc-next-page'] = 'page2'
 
-    allow(knife_bmcs_shape_list.compute_client).to receive(:list_shapes).and_return(response)
+    allow(knife_bmcs_shape_list.compute_client).to receive(:list_shapes).and_return(response, empty_response)
     expect(knife_bmcs_shape_list.ui).to receive(receive_type)
     expect(knife_bmcs_shape_list.ui).to receive(:warn).with('This list has been truncated. To view more items, increase the limit.')
 

--- a/spec/unit/subnet_list_spec.rb
+++ b/spec/unit/subnet_list_spec.rb
@@ -49,10 +49,11 @@ def run_tests(output_format)
   it "shows warning #{output_format} when truncated" do
     knife_bmcs_subnet_list.config = config
     knife_bmcs_subnet_list.config[:format] = output_format
+    knife_bmcs_subnet_list.config[:limit] = 1
     response = multi_response
     response.headers['opc-next-page'] = 'page2'
 
-    allow(knife_bmcs_subnet_list.network_client).to receive(:list_subnets).and_return(response)
+    allow(knife_bmcs_subnet_list.network_client).to receive(:list_subnets).and_return(response, empty_response)
     expect(knife_bmcs_subnet_list.ui).to receive(receive_type)
     expect(knife_bmcs_subnet_list.ui).to receive(:warn).with('This list has been truncated. To view more items, increase the limit.')
 

--- a/spec/unit/vcn_list_spec.rb
+++ b/spec/unit/vcn_list_spec.rb
@@ -4,6 +4,7 @@ require './spec/spec_helper'
 require 'json'
 require 'chef/knife/bmcs_vcn_list'
 
+# rubocop:disable Metrics/AbcSize
 def run_tests(output_format)
   receive_type = output_format == 'summary' ? :list : :output
 
@@ -43,10 +44,11 @@ def run_tests(output_format)
   it "warns #{output_format} when truncated" do
     knife_bmcs_vcn_list.config = config
     knife_bmcs_vcn_list.config[:format] = output_format
+    knife_bmcs_vcn_list.config[:limit] = 1
     response = multi_response
     response.headers['opc-next-page'] = 'page2'
 
-    allow(knife_bmcs_vcn_list.network_client).to receive(:list_vcns).and_return(response)
+    allow(knife_bmcs_vcn_list.network_client).to receive(:list_vcns).and_return(response, empty_response)
     expect(knife_bmcs_vcn_list.ui).to receive(receive_type)
     expect(knife_bmcs_vcn_list.ui).to receive(:warn).with('This list has been truncated. To view more items, increase the limit.')
 


### PR DESCRIPTION
Automatically fetches the next page from the server until all results are retrieved or --limit is reached.  See https://github.com/oracle/knife-bmcs/issues/41
Note: does not yet set a default limit.  Can be added to this changeset or a future changeset if desired.